### PR TITLE
Update language grammars to be more in line with Sublime conventions

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>scope</key>
+  <string>source.swift</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string>// </string>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START_2</string>
+        <key>value</key>
+        <string>/*</string>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_END_2</string>
+        <key>value</key>
+        <string>*/</string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>

--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -25,6 +25,7 @@ contexts:
     - include: generic
     - include: support-class
 
+    - include: literal-import
     - include: literal-function
     - include: literal-class
     - include: literal-struct
@@ -99,11 +100,11 @@ contexts:
 
   curly-brackets:
     - match: '{'
-      scope: punctuation.section.braces.begin.swift
+      scope: punctuation.section.block.begin.swift
       push:
         - meta_scope: meta.braces.swift
         - match: '}'
-          scope: punctuation.section.braces.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
         - include: expression
 
@@ -199,10 +200,10 @@ contexts:
       push:
         - meta_scope: meta.switch.swift
         - match: \}
-          scope: punctuation.section.braces.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
         - match: \{
-          scope: punctuation.section.braces.begin.swift
+          scope: punctuation.section.block.begin.swift
           push:
             - match: (?=})
               pop: true
@@ -232,8 +233,6 @@ contexts:
       captures:
         1: keyword.control.exception.swift
         2: keyword.operator.optional.swift
-    - match: \bimport\b
-      scope: keyword.control.import
     - match: \b(?:as(?:(\?|!)?)|is)(?=\s)
       scope: keyword.operator.cast.swift
     - match: \bwhere\b
@@ -263,7 +262,7 @@ contexts:
       scope: keyword.other.swift
 
   access-attributes:
-    - match: (?>open|public|internal|fileprivate|private)
+    - match: (?>open|public|internal|fileprivate|private|static)
       scope: storage.modifier.swift
 
   function-attributes:
@@ -280,7 +279,7 @@ contexts:
   class_def:
     - meta_scope: meta.class.swift
     - match: \bclass|extension\b
-      scope: storage.type.class.swift
+      scope: keyword.declaration.class.swift
       push: [class_body, class_inherits, class_name]
     - match: (?<=})
       pop: true
@@ -311,10 +310,10 @@ contexts:
 
   class_body:
     - match: '{'
-      scope: punctuation.definition.class.body.begin.swift
+      scope: punctuation.section.block.begin.swift
       set:
         - match: '}'
-          scope: punctuation.definition.class.body.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
         - include: main
 
@@ -384,10 +383,10 @@ contexts:
 
   protocol_body:
     - match: '{'
-      scope: punctuation.definition.protocol.body.begin.swift
+      scope: punctuation.section.block.begin.swift
       set:
         - match: '}'
-          scope: punctuation.definition.protocol.body.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
         # - include: protocol-properties
         # - include: protocol-method-definition
@@ -410,7 +409,7 @@ contexts:
   struct_name:
     - match: (?=\s*:|{)
       pop: true
-    - match: ({{typeIdent}})
+    - match: ({{ident}})
       scope: entity.name.class.swift
       set:
         - include: generic
@@ -430,16 +429,22 @@ contexts:
     - match: (?={)
       pop: true
 
+  struct-method:
+      - meta_scope: meta.struct.function.swift
+      - match: (?={{ident}}\s*\()
+        scope: storage.type.function.swift
+        push: func-name
+      - include: func-end
+
   struct_body:
     - match: '{'
-      scope: punctuation.definition.struct.body.begin.swift
+      scope: punctuation.section.block.begin.swift
       set:
         - match: '}'
-          scope: punctuation.definition.struct.body.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
-        # - include: struct-properties
-        # - include: struct-method-definition
-        # - include: struct-method-storage
+        - include: struct-method
+        - include: expression
         - include: brackets
 
   literal-enum:
@@ -480,12 +485,31 @@ contexts:
 
   enum_body:
     - match: '{'
-      scope: punctuation.definition.enum.body.begin.swift
+      scope: punctuation.section.block.begin.swift
       set:
         - match: '}'
-          scope: punctuation.definition.enum.body.end.swift
+          scope: punctuation.section.block.end.swift
           pop: true
         # - include: enum-cases
+
+  literal-import:
+    - match: \bimport\b\s+
+      scope: keyword.control.import-export.swift
+      set:
+        - import-meta
+        - import-items
+
+  import-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.import.swift
+    - match: ''
+      pop: true
+
+  import-items:
+    - match: \S+
+      scope: variable.other.swift
+    - match: \n
+      pop: true
 
   ##### FUNCTION DECLARATION #####
 
@@ -498,6 +522,9 @@ contexts:
     - match: \bfunc\b
       scope: storage.type.function.swift
       push: func-name
+    - include: func-end
+
+  func-end:
     - match: (?=->)
       set: return-type
     - match: \(
@@ -506,7 +533,7 @@ contexts:
     - match: \)
       scope: punctuation.section.parens.end.swift
     - match: \{
-      scope: punctuation.section.braces.begin.swift
+      scope: punctuation.section.block.begin.swift
       push: function-body
     - match: (?<=})
       pop: true
@@ -525,15 +552,15 @@ contexts:
       set: func-def
 
   parameter:
-    - match: _
-      scope: entity.name.function.swift
+    - match: _(?=\s)
+      scope: variable.language.blank.swift
     - include: type
     - match: '({{ident}})\s*(\:)'
       captures:
         1: variable.parameter.swift
         2: punctuation.separator.swift
     - match: '({{ident}}|_)\b'
-      scope: entity.name.function.swift
+      scope: variable.parameter.argument-label.swift
     - match: ','
       scope: punctuation.separator.swift
 
@@ -547,26 +574,26 @@ contexts:
 
   function-body:
     - match: \}
-      scope: punctuation.section.braces.end.swift
+      scope: punctuation.section.block.end.swift
       pop: true
     - include: main
 
   type:
     - match: ({{typeIdent}})([?!]?)
       captures:
-        1: entity.name.type.swift
+        1: storage.type.swift
         2: keyword.operator.optional.swift
     - match: (\[)({{typeIdent}})([?!]?)(\])([?!]?)
       captures:
         1: punctuation.definition.array.begin.swift
-        2: entity.name.type.swift
+        2: storage.type.swift
         3: keyword.operator.optional.swift
         4: punctuation.definition.array.end.swift
         5: keyword.operator.optional.swift
     - match: (\[)({{typeIdent}})([?!]?)(\:)(\])([?!]?)
       captures:
         1: punctuation.definition.array.begin.swift
-        2: entity.name.type.swift
+        2: storage.type.swift
         3: keyword.operator.optional.swift
         4: punctuation.definition.array.end.swift
         5: keyword.operator.optional.swift\
@@ -582,7 +609,7 @@ contexts:
   literal-variable:
     - match: \b({{typeIdent}})([?!]?)
       captures:
-        1: entity.name.class.swift
+        1: support.class.swift
         2: keyword.operator.optional.swift
     - match: \b({{ident}})([?!]?)
       captures:
@@ -592,13 +619,21 @@ contexts:
       scope: keyword.operator.assignment.swift
 
   literal-function-call:
-    - match: ({{typeIdent}})(\()
-      scope: meta.function-call.swift
+    - match: ({{typeIdent}})\s*(\()
+      scope: meta.block.swift
       captures:
-        1: entity.name.class.swift
+        1: variable.instantiator.swift
         2: punctuation.section.parens.begin.swift
       push: call-parameters
-    - match: (\.)?({{ident}})(\()
+    - match: (\#(?:available|selector))\s*(\()
+      scope: meta.function-call.swift
+      captures:
+        1: variable.language.swift
+        2: punctuation.section.parens.begin.swift
+      push: call-parameters
+    - match: \)
+      scope: punctuation.section.parens.end.swift meta.function-call.swift
+    - match: (\.)?({{ident}})\s*(\()
       scope: meta.function-call.swift
       captures:
         1: punctuation.accessor.swift
@@ -610,7 +645,7 @@ contexts:
 
   call-parameters:
     - match: '({{ident}})\s*\:'
-      scope: variable.function.swift
+      scope: variable.property.swift
     - match: (?=\))
       pop: true
     - include: expression

--- a/syntax_test_swift.swift
+++ b/syntax_test_swift.swift
@@ -30,12 +30,12 @@
 //                       ^ string.quoted.double
 
 {[ (  )] }
-// <- punctuation.section.braces.begin
+// <- punctuation.section.block.begin
  // <- punctuation.section.brackets.begin
 // ^ punctuation.section.parens.begin
 //    ^ punctuation.section.parens.end
 //     ^ punctuation.section.brackets.end
-//       ^ punctuation.section.braces.end
+//       ^ punctuation.section.block.end
 // ^^^^ meta.parens
 //^^^^^^ meta.brackets
 //^^^^^^^^ meta.braces
@@ -48,18 +48,17 @@
 //            ^^^^^ keyword.other
 //                  ^^^^^^^^^^^ storage.modifier
 //                              ^^^^^ storage.modifier
-//                                    ^^^^^ storage.type.class
-
+//                                    ^^^^^ keyword.declaration.class
 class Mvc : MyClass, MyProtocol { }
-// <- storage.type.class
+// <- keyword.declaration.class
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class
 //    ^^^ entity.name.class
 //        ^ punctuation.separator
 //          ^^^^^^^ entity.other.inherited-class
 //                 ^ punctuation.separator
 //                   ^^^^^^^^^^ entity.other.inherited-class
-//                              ^ punctuation.definition.class.body.begin
-//                                ^ punctuation.definition.class.body.end
+//                              ^ punctuation.section.block.begin
+//                                ^ punctuation.section.block.end
 
 class MyClass<Key: Hashable, Value>: Array<Array<String>> { }
 //           ^^^^^^^^^^^^^^^^^^^^^^ meta.generic
@@ -71,7 +70,8 @@ class MyClass<Key: Hashable, Value>: Array<Array<String>> { }
 //                           ^^^^^ variable.other.generic
 //                                ^ punctuation.definition.generic.end
 //                                                     ^^ punctuation.definition.generic.end
-
+//                                                        ^ punctuation.section.block.begin
+//                                                          ^ punctuation.section.block.end
 protocol MyProtocol: class, Other { }
 // <- storage.type.protocol
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.protocol
@@ -80,8 +80,8 @@ protocol MyProtocol: class, Other { }
 //                   ^^^^^ keyword.other
 //                        ^ punctuation.separator
 //                          ^^^^^ entity.other.inherited-class
-//                                ^ punctuation.definition.protocol.body.begin
-//                                  ^ punctuation.definition.protocol.body.end
+//                                ^ punctuation.section.block.begin
+//                                  ^ punctuation.section.block.end
 
 struct MyStruct: Protocol, Other { }
 // <- storage.type.struct
@@ -91,8 +91,8 @@ struct MyStruct: Protocol, Other { }
 //               ^^^^^^^ entity.other.inherited-class
 //                       ^ punctuation.separator
 //                         ^^^^^ entity.other.inherited-class
-//                               ^ punctuation.definition.struct.body.begin
-//                                 ^ punctuation.definition.struct.body.end
+//                               ^ punctuation.section.block.begin
+//                                 ^ punctuation.section.block.end
 
 enum MyEnum<T>: Protocol, Other { }
 // <- storage.type.enum
@@ -103,20 +103,20 @@ enum MyEnum<T>: Protocol, Other { }
 //              ^^^^^^^ entity.other.inherited-class
 //                      ^ punctuation.separator
 //                        ^^^^^ entity.other.inherited-class
-//                              ^ punctuation.definition.enum.body.begin
-//                                ^ punctuation.definition.enum.body.end
+//                              ^ punctuation.section.block.begin
+//                                ^ punctuation.section.block.end
 
 let x: String = "hello"
 // <- storage.type
 //  ^ variable.other.constant
 //   ^ punctuation.separator
-//     ^^^^^^ entity.name.type
+//     ^^^^^^ storage.type
 //            ^ keyword.operator.assignment
 
 var y: Array<String> = ["hello"]
 // <- storage.type
 //  ^ variable.other.readwrite
-//     ^^^^^ entity.name.type
+//     ^^^^^ storage.type
 //          ^^^^^^^^ meta.generic
 
 1.0 + -.46
@@ -156,7 +156,7 @@ for x in array { }
 
 switch myEnum {
 // <- keyword.control.switch
-//            ^ punctuation.section.braces.begin
+//            ^ punctuation.section.block.begin
   case .hello:
 //^^^^ keyword.control.switch
 //           ^ punctuation.separator
@@ -170,7 +170,7 @@ switch myEnum {
 //       ^ punctuation.separator
     print("hi")
 }
-// <- punctuation.section.braces.end
+// <- punctuation.section.block.end
 
 while x == y { }
 // <- keyword.control.loop
@@ -193,20 +193,20 @@ private func myFunc(_ param: Contact, for p2: String) -> Bool { }
 //      ^^^^ storage.type.function
 //           ^^^^^^ entity.name.function
 //                 ^ punctuation.section.parens.begin
-//                  ^ entity.name.function
+//                  ^ variable.language.blank.swift
 //                    ^^^^^ variable.parameter
 //                         ^ punctuation.separator
-//                           ^^^^^^^ entity.name.type
+//                           ^^^^^^^ storage.type
 //                                  ^ punctuation.separator
-//                                    ^^^ entity.name.function
+//                                    ^^^ variable.parameter.argument-label.swift
 //                                        ^^ variable.parameter
 //                                          ^ punctuation.separator
-//                                            ^^^^^^ entity.name.type
+//                                            ^^^^^^ storage.type
 //                                                  ^ punctuation.section.parens.end
 //                                                    ^^ keyword.operator.return
-//                                                       ^^^^ entity.name.type
-//                                                            ^ punctuation.section.braces.begin
-//                                                              ^ punctuation.section.braces.end
+//                                                       ^^^^ storage.type
+//                                                            ^ punctuation.section.block.begin
+//                                                              ^ punctuation.section.block.end
 
 do {
   try?
@@ -221,11 +221,79 @@ do {
 }
 
 extension String { }
+// <- meta.class
+//        ^^^^^^ entity.name.class
 
 MyClass.myVar?.myOtherVar.myFunction() as! NSString
+// <- support.class
+//                        ^^^^^^^^^^ variable.function
+//                                         ^^^^^^^^ support.class
 
 MyClass.myVar?.myOtherVar!.myProperty? = 42
 
 myfunction()
+// <- variable.function
 
+import Cocoa
+//^^^^^^^^^^ meta.import.swift
+// ^ keyword.control.import-export
+//     ^^^^^ variable.other
 
+static let settings = NSToolbarItem.Identifier("Settings")
+// <- storage.modifier
+
+appMenu.submenu?.addItem(NSMenuItem(title: "Hide \(appName)", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h"))
+//                       ^^^^^^^^^^ variable.instantiator
+//                                  ^^^^^^ variable.property.swift
+//                                                                    ^^^^^^^^^ variable.language.swift
+
+if #available(macOS 11.0, *) {
+// ^^^^^^^^^^ variable.language.swift
+
+func doSomething(at time: _PrivateTime) -> Bool {}
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//                        ^^^^^^^^^^^^ storage.type
+
+struct LoadData: Codable {
+    var name: String
+//  ^^^^^^^^^^^^^^^^^ meta.struct.swift
+    var path: String?
+//  ^^^ storage.type
+//      ^^^^ variable.other.readwrite
+//            ^^^^^^ storage.type
+//                  ^ keyword.operator.optional
+}
+
+struct Resolution {
+    var width = 0
+//  ^^^^^^^^^^^^^ meta.struct.swift
+//  ^^^ storage.type
+//      ^^^^^ variable.other.readwrite
+//            ^ keyword.operator.assignment
+//              ^ constant.numeric.integer
+    var height = 0
+}
+
+struct markStruct {
+//                ^ punctuation.section.block.begin.swift
+   var mark1: Int
+   var mark2: Int
+   var mark3: Int
+
+   init(mark1: Int, mark2: Int, mark3: Int) {
+// ^^^^ entity.name.function
+//     ^ punctuation.section.parens.begin
+//      ^^^^^ variable.parameter
+//           ^ punctuation.separator
+//             ^^^ storage.type.swift
+//                ^ punctuation.separator
+//                  ^^^^^ variable.parameter
+//                                        ^ punctuation.section.parens.end
+//                                          ^ meta.braces.swift meta.struct.swift meta.function.swift punctuation.section.block.begin.swift
+      self.mark1 = mark1
+      self.mark2 = mark2
+      self.mark3 = mark3
+   }
+// ^ meta.function punctuation.section.block.end
+}
+// <- punctuation.section.block.end


### PR DESCRIPTION
Hi there. I have been working on some swift projects lately, and I absolutely cannot stand Xcode. Unfortunately, I was also not able to find a really great Sublime Text syntax grammar for Swift. Yours definitely comes the closest out of the ones I tried. I decided to make a few changes and offer them back to you.

This change introduces a bunch of tweaks/improvements to the syntax including:

- Switches to use storage or variable scopes in places where entity was
being used incorrectly
- Updates start and end brackets scope to be more generic using `punctuation.section.block`
- Updates `class` definition to use keyword as opposed to storage
- Updates argument labels in function declarations to use new scope
- Updates import syntax to be more like other languages
- Adds support for static keyword
- Adds support for `#selector` and `#available` methods
- Adds some missing tests to code blocks in the syntax_test_swift file
- Adds support for variable and function declarations within struct
blocks

These changes are not exhaustive, but should make things match up more closely with other languages in Sublime Text.

Related to sublimehq/Packages#11

---

## Screenshots

To give you an idea of what the changes look like visually

### Before

<img alt="syntax before" src="https://user-images.githubusercontent.com/259316/125390940-a0971e80-e371-11eb-9362-b1feed0e8a91.png" width="641" height="631" />

### After

<img alt="syntax after" src="https://user-images.githubusercontent.com/259316/125390959-a7259600-e371-11eb-8d7b-1f95a9583402.png" width="642" height="626" />
